### PR TITLE
Improve SSH client robustness and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,14 @@ python -m fmc_ssh.main -s <SERVER_IP> -p <PASSWORD> [-c <COMMAND>]
 - `-p`, `--password` – password for the `admin` user.
 - `-c`, `--command` – optional command to run after obtaining root shell. If omitted, an interactive shell is opened.
 
-The script logs in as `admin`, enters expert mode and elevates to root automatically. When a command is supplied, its output is printed and the session closes. Without a command, an interactive prompt is provided until you type `exit`.
+The script logs in as `admin`, enters expert mode and elevates to root automatically. When a command is supplied, its output is printed and the session closes. Without a command, an interactive prompt is provided until you type `exit` or press `Ctrl-C`.
+
+You can also use the client as a context manager:
+
+```python
+from fmc_ssh import FMCSSHClient
+
+with FMCSSHClient("10.0.0.1", "p@ssw0rd") as client:
+    print(client.run_command("ls"))
+```
 

--- a/fmc_ssh/client.py
+++ b/fmc_ssh/client.py
@@ -1,49 +1,92 @@
-import paramiko
+import ipaddress
+import logging
+import re
 import time
-from typing import Optional, Tuple
+from typing import Optional
+
+import paramiko
 
 class FMCSSHClient:
-    """Client to handle SSH interaction with FMC server."""
+    """Client to handle SSH interaction with an FMC server."""
 
-    def __init__(self, host: str, password: str, user: str = "admin"):
+    def __init__(
+        self,
+        host: str,
+        password: str,
+        user: str = "admin",
+        ssh_client: Optional[paramiko.SSHClient] = None,
+    ) -> None:
+        if not host or not self._is_valid_host(host):
+            raise ValueError("Invalid host provided")
+        if not password:
+            raise ValueError("Password must be provided")
+
         self.host = host
         self.user = user
         self.password = password
-        self.client = None
+        self.client: paramiko.SSHClient = ssh_client or paramiko.SSHClient()
         self.channel = None
+        logging.getLogger(__name__).debug("FMCSSHClient initialised for %s", host)
 
-    def connect(self):
-        self.client = paramiko.SSHClient()
+    def __enter__(self) -> "FMCSSHClient":
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    @staticmethod
+    def _is_valid_host(value: str) -> bool:
+        try:
+            ipaddress.ip_address(value)
+            return True
+        except ValueError:
+            return re.match(r"^[a-zA-Z0-9.-]+$", value) is not None
+
+    def connect(self) -> None:
+        """Open the SSH connection and elevate to root."""
+        logger = logging.getLogger(__name__)
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        self.client.connect(hostname=self.host, username=self.user, password=self.password)
-        self.channel = self.client.invoke_shell()
-        self._wait_for_prompt('>')
-        self.channel.send('expert\n')
-        self._wait_for_prompt(':~$')
-        self.channel.send('sudo su -\n')
-        self._wait_for_prompt('Password:')
-        self.channel.send(self.password + '\n')
-        self._wait_for_prompt(':~#')
+        try:
+            self.client.connect(hostname=self.host, username=self.user, password=self.password)
+            self.channel = self.client.invoke_shell()
+            self._wait_for_prompt('>')
+            self._send_and_wait('expert', ':~$')
+            self._send_and_wait('sudo su -', 'Password:')
+            self._send_and_wait(self.password, ':~#')
+            logger.debug("Connected to %s", self.host)
+        except paramiko.SSHException as exc:
+            logger.error("SSH connection failed: %s", exc)
+            self.close()
+            raise ConnectionError(f"Failed to connect to {self.host}") from exc
+
+    def _send_and_wait(self, command: str, prompt: str) -> str:
+        """Send a command and wait for the given prompt."""
+        if not self.channel:
+            raise RuntimeError("SSH channel is not open")
+        self.channel.send(command + "\n")
+        return self._wait_for_prompt(prompt)
 
     def _wait_for_prompt(self, prompt: str, timeout: int = 30) -> str:
-        buff = ''
+        if not self.channel:
+            raise RuntimeError("SSH channel is not open")
+        buff = ""
         start = time.time()
         while not buff.strip().endswith(prompt):
             if self.channel.recv_ready():
-                buff += self.channel.recv(1024).decode('utf-8')
+                buff += self.channel.recv(1024).decode("utf-8")
             if time.time() - start > timeout:
-                raise TimeoutError(f'Timeout waiting for prompt: {prompt}')
+                raise TimeoutError(f"Timeout waiting for prompt: {prompt}")
             time.sleep(0.1)
         return buff
 
     def run_command(self, command: str) -> str:
-        self.channel.send(command + '\n')
-        output = self._wait_for_prompt(':~#')
-        return output
+        return self._send_and_wait(command, ':~#')
 
     def close(self):
         if self.client:
             self.client.close()
+        self.channel = None
 
 
     def interactive_shell(self):
@@ -52,7 +95,10 @@ class FMCSSHClient:
                 cmd = input('fmc# ')
                 if cmd.strip().lower() in ('exit', 'quit'):
                     break
+                if not cmd.strip():
+                    continue
                 output = self.run_command(cmd)
                 print(output, end='')
-        finally:
-            self.close()
+        except KeyboardInterrupt:
+            print()
+


### PR DESCRIPTION
## Summary
- validate connection parameters and add context manager
- add logging and internal helpers for command execution
- improve CLI argument validation and error handling
- document context manager usage in README
- add unit tests with a paramiko stub

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b62bef5cc832284b3339fd29f5b97