### PR TITLE
Add optional SSH port support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ This repository provides a simple Python utility to connect to a Firepower Manag
 ## Usage
 
 ```
-python -m fmc_ssh.main -s <SERVER_IP> -p <PASSWORD> [-c <COMMAND>]
+python -m fmc_ssh.main -s <SERVER_IP> -p <PASSWORD> [-P <PORT>] [-c <COMMAND>]
 ```
 
 - `-s`, `--server` – IP address of the FMC server.
 - `-p`, `--password` – password for the `admin` user.
+- `-P`, `--port` – SSH port number if not 22.
 - `-c`, `--command` – optional command to run after obtaining root shell. If omitted, an interactive shell is opened.
 
 The script logs in as `admin`, enters expert mode and elevates to root automatically. When a command is supplied, its output is printed and the session closes. Without a command, an interactive prompt is provided until you type `exit` or press `Ctrl-C`.
@@ -24,7 +25,7 @@ You can also use the client as a context manager:
 ```python
 from fmc_ssh import FMCSSHClient
 
-with FMCSSHClient("10.0.0.1", "p@ssw0rd") as client:
+with FMCSSHClient("10.0.0.1", "p@ssw0rd", port=22) as client:
     print(client.run_command("ls"))
 ```
 

--- a/fmc_ssh/client.py
+++ b/fmc_ssh/client.py
@@ -14,6 +14,7 @@ class FMCSSHClient:
         host: str,
         password: str,
         user: str = "admin",
+        port: int = 22,
         ssh_client: Optional[paramiko.SSHClient] = None,
     ) -> None:
         if not host or not self._is_valid_host(host):
@@ -24,6 +25,7 @@ class FMCSSHClient:
         self.host = host
         self.user = user
         self.password = password
+        self.port = port
         self.client: paramiko.SSHClient = ssh_client or paramiko.SSHClient()
         self.channel = None
         logging.getLogger(__name__).debug("FMCSSHClient initialised for %s", host)
@@ -48,7 +50,7 @@ class FMCSSHClient:
         logger = logging.getLogger(__name__)
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:
-            self.client.connect(hostname=self.host, username=self.user, password=self.password)
+            self.client.connect(hostname=self.host, username=self.user, password=self.password, port=self.port)
             self.channel = self.client.invoke_shell()
             self._wait_for_prompt('>')
             self._send_and_wait('expert', ':~$')

--- a/fmc_ssh/main.py
+++ b/fmc_ssh/main.py
@@ -32,6 +32,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Connect to FMC server via SSH")
     parser.add_argument('-s', '--server', required=True, help='FMC server IP address')
     parser.add_argument('-p', '--password', required=True, help='Password for admin user')
+    parser.add_argument('-P', '--port', type=int, default=22, help='SSH port number (default 22)')
     parser.add_argument('-c', '--command', help='Command to run on the server')
     args = parser.parse_args()
     if not args.password.strip():
@@ -44,7 +45,7 @@ def parse_args():
 def main():
     args = parse_args()
     try:
-        with FMCSSHClient(args.server, args.password) as client:
+        with FMCSSHClient(args.server, args.password, port=args.port) as client:
             if args.command:
                 output = client.run_command(args.command)
                 print(output, end='')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,6 +42,15 @@ class TestFMCSSHClient(unittest.TestCase):
             client.connect.assert_called_once()
         client.close.assert_called_once()
 
+    def test_connect_uses_given_port(self):
+        ssh_client = MagicMock()
+        ssh_client.invoke_shell.return_value = MagicMock()
+        client = FMCSSHClient('1.2.3.4', 'pass', port=2222, ssh_client=ssh_client)
+        client._wait_for_prompt = MagicMock()
+        client._send_and_wait = MagicMock()
+        client.connect()
+        ssh_client.connect.assert_called_with(hostname='1.2.3.4', username='admin', password='pass', port=2222)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow optional SSH port configuration in `FMCSSHClient`
- expose port CLI flag in `main.py`
- document port option in README
- verify port usage in tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686b7f0595c48322ad9ff91447e7b1e6