### PR TITLE
Read password from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ This repository provides a simple Python utility to connect to a Firepower Manag
 ## Usage
 
 ```
-python -m fmc_ssh.main -s <SERVER_IP> -p <PASSWORD> [-P <PORT>] [-c <COMMAND>]
+python -m fmc_ssh.main -s <SERVER_IP> [-P <PORT>] [-c <COMMAND>]
 ```
 
 - `-s`, `--server` – IP address of the FMC server.
-- `-p`, `--password` – password for the `admin` user.
+- The password for the `admin` user is read from `config/remote_access.properties`.
 - `-P`, `--port` – SSH port number if not 22.
 - `-c`, `--command` – optional command to run after obtaining root shell. If omitted, an interactive shell is opened.
+
+Create a file `config/remote_access.properties` alongside the code with a line like:
+
+```
+password=YOUR_PASSWORD
+```
 
 The script logs in as `admin`, enters expert mode and elevates to root automatically. When a command is supplied, its output is printed and the session closes. Without a command, an interactive prompt is provided until you type `exit` or press `Ctrl-C`.
 

--- a/config/remote_access.properties
+++ b/config/remote_access.properties
@@ -1,0 +1,3 @@
+# Application configuration
+# Set the admin password for SSH access
+password=


### PR DESCRIPTION
## Summary
- load password from `config/remote_access.properties`
- update CLI help and usage docs
- document how to supply password

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686b8f576f848322a7725ca31e9bcb41